### PR TITLE
Fix peer dependency warning when using MST 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "reactotron-core-client": "^2.5.0",
     "mobx": "^3.4.1 || ^4.1.0",
-    "mobx-state-tree": "^1.4.0 || ^2.0.2"
+    "mobx-state-tree": "^1.4.0 || ^2.0.2 || ^3.0.0"
   },
   "dependencies": {
     "ramda": "^0.25.0"


### PR DESCRIPTION
We've been using this with MST 3.x for a while now so I think it's time to remove the peer dependency warning 😄 